### PR TITLE
Fix typo

### DIFF
--- a/website/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/website/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -17,7 +17,7 @@ To keep our learning gradual we'll stick to in-memory data for now but rest assu
 
 The first thing we'll do is setup an in-memory database and expose it to our resolvers using the _GraphQL context_.
 
-The GraphQL Context is a plain JavaScript object shared across all resolvers. Nexus creates a new one for each request and adds a few of its own properties. Largely though, what it will contains will be defined by your app. It is a good place to, for example, attach information about the logged-in user.
+The GraphQL Context is a plain JavaScript object shared across all resolvers. Nexus creates a new one for each request and adds a few of its own properties. Largely though, what it contains will be defined by your app. It is a good place to, for example, attach information about the logged-in user.
 
 So go ahead and create the database.
 


### PR DESCRIPTION
Just fixes a tiny typo I noticed in the docs

#### TODO

- [ ] docs
  - [ ] jsdoc
  - [ ] website api
  - [ ] website guides
  - [ ] website tutorial
- [ ] tests
